### PR TITLE
Proposed fix for issue #40.

### DIFF
--- a/languages/brazilian_portuguese.json
+++ b/languages/brazilian_portuguese.json
@@ -58,7 +58,7 @@
 	"Highlighting":"Realce de sintaxe",
 	"Settings-Advanced-Performance-Animations":"Desligue para desativar as animações. ",
 	"Settings-Advanced-FactoryReset-text":"Isto irá reiniciar as configurações do Graviton  e limpará a lista de projetos recentes.",
-	"Settings-Advanced-Developer-Tools-text":"Alternar para ferramentas de desenvolvedor"
+	"Settings-Advanced-Developer-Tools-text":"Alternar para ferramentas de desenvolvedor",
 	"FileExit-dialog-message":"Tem certeza de fechar este arquivo sem salvá-lo",
 	"FileExit-dialog-button-accept":"Sim, Fechar",
 	"FileExit-dialog-button-deny":"Não, Salvar",


### PR DESCRIPTION
- Renamed file `languages/brazilian_portuguese` to `languages/brazilian_portuguese.json` for consistency,
- Added missing comma.