### PR TITLE
Fix dialogs closing on click

### DIFF
--- a/src/javascript/api/constructors/dialogs.js
+++ b/src/javascript/api/constructors/dialogs.js
@@ -69,7 +69,7 @@ module.exports = {
     const dialogComponent = puffin.element(`
       <div id="${id + '_dialog'}" myID="${id}">
         <div myID="${id}" class="background_window" onclick="closeDialog('${id}')">
-          <div style="animation: ${openingAnimation}" class="dialog_body">
+          <div style="animation: ${openingAnimation}" class="dialog_body" onclick="event.stopPropagation()">
             <h3 >${title}</h3>
             <div style="font-size:15px; min-height:15px; position:relative;">
               <elastic-container related="self">


### PR DESCRIPTION
Fix the click event passing through the dialog to the scrim causing the dialog to close when you click on it.