### PR TITLE
Fix 'Uncaught (in promise) ReferenceError: normalizeDir is not defined'

### DIFF
--- a/src/javascript/utils/dialogs/select.file.js
+++ b/src/javascript/utils/dialogs/select.file.js
@@ -1,4 +1,5 @@
 const { remote } = window.require("electron")
+import normalizeDir from  '../directory.normalizer'
 
 function selectFileDialog(){
 	return new Promise((resolve, reject) => {

--- a/src/javascript/utils/dialogs/select.folder.js
+++ b/src/javascript/utils/dialogs/select.folder.js
@@ -1,4 +1,5 @@
 const { remote } = window.require("electron")
+import normalizeDir from  '../directory.normalizer'
 
 function selectFolderDialog(){
 	return new Promise((resolve, reject) => {


### PR DESCRIPTION
An error is thrown when opening folders and files because normalizeDir is not imported, so this commit adds the imports for it.