### PR TITLE
Ignore .idea/ for Jetbrains tools and .DS_Store for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ npm-debug.log
 dist_main
 .DS_Store
 .idea/
+.vscode
+.vs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pluginsDist
 dist_ui
 npm-debug.log
 dist_main
+.DS_Store
+.idea/


### PR DESCRIPTION
`.idea/` is a folder containing metadata for Jetbrains IDEs such as PyCharm, WebStorm, and Intellij
`.DS_Store` is stores metadata for Finder on MacOS