### PR TITLE
Deleted two hyphen, now the term looks like on v1.2.0

### DIFF
--- a/src/interface/components/terminal.ts
+++ b/src/interface/components/terminal.ts
@@ -113,7 +113,6 @@ const getConfig = () => {
 		cursorBlink: true,
 		fontSize: 13,
 		lineHeight: 1.4,
-		letterSpacing: -2,
 		windowsMode: process.platform === 'win32',
 	}
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -21,7 +21,7 @@ body {
 		font-family: var(--puffinFont);
 	}
 	.xterm * {
-		font-family: var(----codeFont) !important;
+		font-family: var(--codeFont) !important;
 	}
 }
 @font-face {


### PR DESCRIPTION
There were two extra hyphens on the main.css file which provokes the Xterm.js malfunction. So I deleted them and I also deleted the negative letter-spacing on the Xterm.js configuration.  (related to issue #203)
![gravitonFix](https://user-images.githubusercontent.com/44611837/95665192-48b35900-0b4e-11eb-99a0-0ed7632ce23e.png)
