### PR TITLE
Use PORT if possible

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -105,6 +105,6 @@ app.ws('/api/ws', ws => {
 	})
 })
 
-app.listen(8080, () => {
+app.listen(process.env.PORT || 8080, () => {
 	console.log('listening in port 8080')
 })


### PR DESCRIPTION
Some providers, like Heroku, define the PORT env variable to define where to serve (heroku for example). That's why I created this PR.