### PR TITLE
Determine language based on the OS' language

### DIFF
--- a/languages/default.json
+++ b/languages/default.json
@@ -1,0 +1,3 @@
+{
+	"name": "Default"
+}

--- a/src/interface/collections/languages.ts
+++ b/src/interface/collections/languages.ts
@@ -12,7 +12,7 @@ import pl from '../../../languages/polish.json'
 import ar from '../../../languages/arabic.json'
 import tr from '../../../languages/turkish.json'
 import zh from '../../../languages/chinese-simplified.json'
-import eel from '../../../languages/greek.json'
+import el from '../../../languages/greek.json'
 
 export default {
 	def,
@@ -29,5 +29,5 @@ export default {
 	ar,
 	tr,
 	zh,
-	eel,
+	el,
 }

--- a/src/interface/collections/languages.ts
+++ b/src/interface/collections/languages.ts
@@ -1,31 +1,33 @@
-import english from '../../../languages/english.json'
-import catalan from '../../../languages/catalan.json'
-import classical_latin from '../../../languages/classical_latin.json'
-import brazilian_portuguese from '../../../languages/brazilian_portuguese.json'
-import french from '../../../languages/french.json'
-import german from '../../../languages/german.json'
-import italian from '../../../languages/italian.json'
-import russian from '../../../languages/russian.json'
-import spanish from '../../../languages/spanish.json'
-import polish from '../../../languages/polish.json'
-import arabic from '../../../languages/arabic.json'
-import turkish from '../../../languages/turkish.json'
-import simplifiedChinese from '../../../languages/chinese-simplified.json'
-import greek from '../../../languages/greek.json'
+import def from '../../../languages/default.json'
+import en from '../../../languages/english.json'
+import cat from '../../../languages/catalan.json'
+import la from '../../../languages/classical_latin.json'
+import pt from '../../../languages/brazilian_portuguese.json'
+import fr from '../../../languages/french.json'
+import de from '../../../languages/german.json'
+import it from '../../../languages/italian.json'
+import ru from '../../../languages/russian.json'
+import es from '../../../languages/spanish.json'
+import pl from '../../../languages/polish.json'
+import ar from '../../../languages/arabic.json'
+import tr from '../../../languages/turkish.json'
+import zh from '../../../languages/chinese-simplified.json'
+import el from '../../../languages/greek.json'
 
 export default {
-	english,
-	catalan,
-	classical_latin,
-	brazilian_portuguese,
-	french,
-	german,
-	italian,
-	russian,
-	spanish,
-	polish,
-	arabic,
-	turkish,
-	simplifiedChinese,
-	greek,
+	def,
+	en,
+	cat,
+	la,
+	pt,
+	fr,
+	de,
+	it,
+	ru,
+	es,
+	pl,
+	ar,
+	tr,
+	zh,
+	el,
 }

--- a/src/interface/collections/languages.ts
+++ b/src/interface/collections/languages.ts
@@ -12,7 +12,7 @@ import pl from '../../../languages/polish.json'
 import ar from '../../../languages/arabic.json'
 import tr from '../../../languages/turkish.json'
 import zh from '../../../languages/chinese-simplified.json'
-import el from '../../../languages/greek.json'
+import eel from '../../../languages/greek.json'
 
 export default {
 	def,
@@ -29,5 +29,5 @@ export default {
 	ar,
 	tr,
 	zh,
-	el,
+	eel,
 }

--- a/src/interface/core/lang_config.ts
+++ b/src/interface/core/lang_config.ts
@@ -22,7 +22,7 @@ const LanguageState: PuffinState = new state({
 })
 
 function setFallback(notFoundLang: string): void {
-	StaticConfig.data.appLanguage = 'english'
+	StaticConfig.data.appLanguage = 'en'
 	LanguageState.data.translations = Languages[StaticConfig.data.appLanguage].translations
 	const err = `Couldnt find language by name ${notFoundLang}`
 	throwError(err, err)
@@ -32,6 +32,8 @@ StaticConfig.keyChanged('appLanguage', (newLanguage: string) => {
 	if (Languages[newLanguage].name === 'Default') {
 		if (Languages[globalAny.navigator.language]) {
 			LanguageState.data.translations = Languages[globalAny.navigator.language].translations
+		} else {
+			setFallback(globalAny.navigator.language)
 		}
 	} else if (Languages[newLanguage]) {
 		LanguageState.data.translations = Languages[newLanguage].translations

--- a/src/interface/core/lang_config.ts
+++ b/src/interface/core/lang_config.ts
@@ -3,6 +3,7 @@ import Languages from '../collections/languages'
 import StaticConfig from 'StaticConfig'
 import throwError from '../utils/throw_error'
 import { PuffinState } from 'Types/puffin.state'
+const globalAny: any = global
 
 let initialTranslations = {}
 
@@ -10,14 +11,14 @@ if (Languages[StaticConfig.data.appLanguage]) {
 	const data = Languages[StaticConfig.data.appLanguage].translations
 	initialTranslations = data
 } else {
-	initialTranslations = Languages.english.translations
+	initialTranslations = Languages.en.translations
 	const err = `Couldnt find language by name ${StaticConfig.data.appLanguage}`
 	throwError(err, err)
 }
 
 const LanguageState: PuffinState = new state({
 	translations: initialTranslations,
-	fallbackTranslations: Languages.english.translations,
+	fallbackTranslations: Languages.en.translations,
 })
 
 function setFallback(notFoundLang: string): void {
@@ -28,7 +29,11 @@ function setFallback(notFoundLang: string): void {
 }
 
 StaticConfig.keyChanged('appLanguage', (newLanguage: string) => {
-	if (Languages[newLanguage]) {
+	if (Languages[newLanguage].name === 'Default') {
+		if (Languages[globalAny.navigator.language]) {
+			LanguageState.data.translations = Languages[globalAny.navigator.language].translations
+		}
+	} else if (Languages[newLanguage]) {
 		LanguageState.data.translations = Languages[newLanguage].translations
 	} else {
 		//Fallback to english if the configured language is not found


### PR DESCRIPTION
Hey. Closes #251. This approach renames languages to their locales so the use of `navigator.language` is easier. It could also be done using a `switch` statement, but I believe this is easier for future translations.