### PR TITLE
[Development improvement] Add Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+
 image: gitpod/workspace-full
 
 tasks:
@@ -7,3 +8,6 @@ tasks:
   - name: Web
     init: npm i yarn -g && cd web && yarn
     command: yarn dev
+vscode:
+  extensions:
+    - rust-lang.rust

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 
-image: gitpod/workspace-full
+image: gitpod/workspace-full-vnc
 
 tasks:
   - name: Rust
@@ -8,6 +8,11 @@ tasks:
   - name: Web
     init: npm i yarn -g && cd web && yarn
     command: yarn dev
+
 vscode:
   extensions:
     - rust-lang.rust
+
+ports:
+  - port: 6080
+    onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image: gitpod/workspace-full
+
+tasks:
+  - name: Rust
+    init: cargo build
+    command: cargo run --example demo
+  - name: Web
+    init: npm i yarn -g && cd web && yarn
+    command: yarn dev

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Graviton-Code-Editor/Graviton-App/tree/graviton-rewrite)
+
 Graviton Rewrite discussion: https://github.com/Graviton-Code-Editor/Graviton-App/discussions/292
 ## Running
 Run a core:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Gitpod is an online coding platform.

Keep in mind that when graviton-rewrite is merged to main, you should remove /tree/graviton-rewrite from the URL in gitpod's badge.

## Tasks
- [ ] Graviton web won't connect to the correct URL (ws). as a workaround, open gitpod in vscode. as a true workaround, create a WS_URL env variable that points to the correct URL.